### PR TITLE
Update Python requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Salida única: toda la transcripción se guarda en un solo fichero de texto.
 
 macOS, Linux o Windows.
 
-Python 3.8+.
+Python 3.9+.
 
 Entorno virtual de Python (venv).
 


### PR DESCRIPTION
## Summary
- update README to require Python 3.9+

## Testing
- `python3 -m py_compile split_and_transcribe.py`


------
https://chatgpt.com/codex/tasks/task_b_686e48460414832ebca54012297b9b8f